### PR TITLE
Feature/bds#197 accordion documentation

### DIFF
--- a/app/components/ch/components/Accordion.vue
+++ b/app/components/ch/components/Accordion.vue
@@ -4,49 +4,17 @@
     class="accordion "
     :class="spaced ? 'accordion--spaced' : ''"
   >
-  <li
-    v-for="(item, key) in content"
-    :key="`${key}`"
-    class="accordion__item"
-  >
-    <button
-      class="accordion__button"
-      aria-expanded="false"
-      :aria-controls="`content-${id}-${key}`"
-      :id="`accordion-control-${id}-${key}`"
-    >
-      <h3 class="accordion__title">
-        {{ item.title }}
-      </h3>
-      <SvgIcon
-        icon="ChevronDown"
-        size="xl"
-        class="accordion__arrow"
-      />
-    </button>
-    <div
-      class="accordion__drawer"
-      aria-hidden="true"
-      :id="`content-${id}-${key}`"
-    >
-      <div
-        class="accordion__content"
-        v-html="item.content"
-      />
-    </div>
-  </li>
+    <slot />
 </ul>
 </template>
 
 <script>
 import Accordion from '../../../scripts/Accordion.js'
-import SvgIcon from '../components/SvgIcon.vue'
 
 export default {
   name: 'Accordion',
   components: {
-    Accordion,
-    SvgIcon
+    Accordion
   },
   props: {
     id: {
@@ -56,10 +24,6 @@ export default {
     spaced: {
       type: Boolean,
       default: false
-    },
-    content: {
-      type: Array,
-      required: true
     }
   },
   

--- a/app/components/ch/components/AccordionItem.vue
+++ b/app/components/ch/components/AccordionItem.vue
@@ -1,0 +1,67 @@
+<template>
+  <li
+    class="accordion__item"
+  >
+    <button
+      class="accordion__button"
+      aria-expanded="false"
+      :aria-controls="`content-${id}`"
+      :id="`accordion-control-${id}`"
+    >
+      <component
+        :is="headinglevel"
+        class="accordion__title"
+      >
+        {{ title }}
+      </component>
+      <SvgIcon
+        icon="ChevronDown"
+        size="xl"
+        class="accordion__arrow"
+      />
+    </button>
+    <div
+      class="accordion__drawer"
+      aria-hidden="true"
+      :id="`content-${id}`"
+    >
+      <div class="accordion__content">
+        <slot />
+      </div>
+      </div>
+    </div>
+  </li>
+</template>
+
+<script>
+import SvgIcon from '../components/SvgIcon.vue'
+import MetaInfo from './MetaInfo.vue'
+export default {
+  name: 'AccordionItem',
+  components: {
+    SvgIcon,
+    MetaInfo,
+  },
+  props: {
+    id: {
+      type: String,
+      required: true
+    },
+    title: {
+      type: String,
+      required: true
+    },
+    headinglevel: {
+      type: String,
+      default: 'h3',
+      validator: (prop) => [
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'div'
+      ].includes(prop)
+    }
+  },
+}
+</script>

--- a/app/components/ch/components/AccordionItem.vue
+++ b/app/components/ch/components/AccordionItem.vue
@@ -9,7 +9,7 @@
       :id="`accordion-control-${id}`"
     >
       <component
-        :is="headinglevel"
+        :is="tag"
         class="accordion__title"
       >
         {{ title }}
@@ -27,7 +27,6 @@
     >
       <div class="accordion__content">
         <slot />
-      </div>
       </div>
     </div>
   </li>
@@ -51,7 +50,7 @@ export default {
       type: String,
       required: true
     },
-    headinglevel: {
+    headingLevel: {
       type: String,
       default: 'h3',
       validator: (prop) => [
@@ -63,5 +62,10 @@ export default {
       ].includes(prop)
     }
   },
+  computed: {
+    tag () {
+      return this.headingLevel
+    }
+  }
 }
 </script>

--- a/app/components/ch/components/Card.vue
+++ b/app/components/ch/components/Card.vue
@@ -33,7 +33,8 @@ export default {
         'default',
         'highlight',
         'image-left',
-        'twitter'
+        'twitter',
+        'flat'
       ].includes(prop)
     },
   },

--- a/app/components/ch/components/Card.vue
+++ b/app/components/ch/components/Card.vue
@@ -32,7 +32,6 @@ export default {
       validator: (prop) => [
         'default',
         'highlight',
-        'image-left',
         'twitter',
         'flat'
       ].includes(prop)

--- a/app/components/ch/sections/MoreInfosAccordionSection.vue
+++ b/app/components/ch/sections/MoreInfosAccordionSection.vue
@@ -30,7 +30,7 @@
           >
             <Card type="flat">
               <template v-slot:body>
-                <h4 class="h5">Flat Card example</h4>
+                <h4 class="card__title">Flat Card example</h4>
                 <p>Digitale Karten und Geoinformation im Unterricht</p>
               </template>
               <template v-slot:footerInfo>
@@ -48,7 +48,7 @@
             </Card>
             <Card type="flat">
               <template v-slot:body>
-                <h4 class="h5">Flat Card example</h4>
+                <h4 class="card__title">Flat Card example</h4>
                 <p>Digitale Karten und Geoinformation im Unterricht</p>
               </template>
               <template v-slot:footerInfo>

--- a/app/components/ch/sections/MoreInfosAccordionSection.vue
+++ b/app/components/ch/sections/MoreInfosAccordionSection.vue
@@ -113,8 +113,21 @@
             title="Reden"
             headingLevel="h3"
           >
-            AccordionItem Content here<br />
-            2nd line
+            <figure>
+              <picture>
+                <source
+                  srcset="https://placekitten.com/g/1600/900"
+                  media="(min-width: 800px)"
+                />
+                <img src="https://placekitten.com/g/1600/1200" alt="cat" />
+              </picture>
+              <figcaption>
+                Datenmodelle als http-Ressource nutzbar zu machen. Der Vorteil für
+                einen Benutzer liegt darin, dass die Modelldateien und evtl.
+                weitere importierte Datenmodelle nicht lokal vorhanden sein müssen
+                —&nbsp;©&nbsp;Photograph Name
+              </figcaption>
+            </figure>
           </AccordionItem>
 
           <AccordionItem 

--- a/app/components/ch/sections/MoreInfosAccordionSection.vue
+++ b/app/components/ch/sections/MoreInfosAccordionSection.vue
@@ -85,15 +85,6 @@
 
           <AccordionItem 
             id="11"
-            title="Reden"
-            headingLevel="h3"
-          >
-            AccordionItem Content here<br />
-            2nd line
-          </AccordionItem>
-
-          <AccordionItem 
-            id="11"
             title="Dokumente und Downloads"
             headingLevel="h3"
           >
@@ -115,6 +106,15 @@
                 :date="'22.01.2022'"
               />
             </ul>
+          </AccordionItem>
+
+          <AccordionItem 
+            id="11"
+            title="Reden"
+            headingLevel="h3"
+          >
+            AccordionItem Content here<br />
+            2nd line
           </AccordionItem>
 
           <AccordionItem 

--- a/app/components/ch/sections/MoreInfosAccordionSection.vue
+++ b/app/components/ch/sections/MoreInfosAccordionSection.vue
@@ -1,0 +1,161 @@
+<template>
+  <section class="section section--default">
+    <div class="container container--grid gap--responsive">
+      <div class="container__center--xs vertical-spacing">
+        <h2 class="h2">
+          Weitere Informationen
+        </h2>
+        
+        <Accordion id="100">
+          
+          <AccordionItem 
+            id="10"
+            title="Medienmitteilungen"
+            headingLevel="h3"
+          >
+            <h3 class="h5">Title h3</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor</p>
+            <ul class="list list--default">
+              <li>List example</li>
+              <li>
+                List example with <a href="#" target="_blank">external link</a>
+              </li>
+            </ul>
+          </AccordionItem>
+
+          <AccordionItem 
+            id="11"
+            title="Interviews"
+            headingLevel="h3"
+          >
+            <Card type="flat">
+              <template v-slot:body>
+                <h4 class="h5">Flat Card example</h4>
+                <p>Digitale Karten und Geoinformation im Unterricht</p>
+              </template>
+              <template v-slot:footerInfo>
+                22. März 2012
+              </template>
+              <template v-slot:footerAction>
+                <Btn
+                  to="#"
+                  variant="outline"
+                  icon-pos="only"
+                  icon="ArrowRight"
+                  label="Mehr anschauen"
+                />
+              </template>
+            </Card>
+            <Card type="flat">
+              <template v-slot:body>
+                <h4 class="h5">Flat Card example</h4>
+                <p>Digitale Karten und Geoinformation im Unterricht</p>
+              </template>
+              <template v-slot:footerInfo>
+                22. März 2012
+              </template>
+              <template v-slot:footerAction>
+                <Btn
+                  to="#"
+                  variant="outline"
+                  icon-pos="only"
+                  icon="ArrowRight"
+                  label="Mehr anschauen"
+                />
+              </template>
+            </Card>
+            <Card type="flat">
+              <template v-slot:body>
+                Swisstopo Daten sind neu in geo.admin.ch Geo- und Downloaddiensten kostenlos...
+              </template>
+              <template v-slot:footerInfo>
+                22. März 2012
+              </template>
+              <template v-slot:footerAction>
+                <Btn
+                  to="#"
+                  variant="outline"
+                  icon-pos="only"
+                  icon="ArrowRight"
+                  label="Mehr anschauen"
+                />
+              </template>
+            </Card>
+          </AccordionItem>
+
+          <AccordionItem 
+            id="11"
+            title="Reden"
+            headingLevel="h3"
+          >
+            AccordionItem Content here<br />
+            2nd line
+          </AccordionItem>
+
+          <AccordionItem 
+            id="11"
+            title="Dokumente und Downloads"
+            headingLevel="h3"
+          >
+            <ul class="download-items">
+              <DownloadItem
+                :filename="'dummy.pdf'"
+                :title="'Information on the usage of websites'"
+                description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean feugiat augue eu purus luctus rhoncus. Donec ultricies venenatis nibh, vel placerat est accumsan quis. Maecenas urna nibh, pretium pretium odio id, rhoncus rhoncus lorem. Nulla eu neque sagittis, cursus purus eget, sodales est. Duis at ultrices odio, ac egestas dolor."
+                :url="'../../../static/documents/dummy.pdf'"
+                :type="'PDF'"
+                :date="'22.01.2022'"
+              />
+              <DownloadItem
+                :filename="'image.png'"
+                :title="'Information on the usage of websites'"
+                description=""
+                :url="'../../../static/images/html-structure.png'"
+                :type="'PNG'"
+                :date="'22.01.2022'"
+              />
+            </ul>
+          </AccordionItem>
+
+          <AccordionItem 
+            id="11"
+            title="Parlament"
+            headingLevel="h3"
+          >
+            AccordionItem Content here
+          </AccordionItem>
+
+          <AccordionItem 
+            id="11"
+            title="Gesetze und Verordnungen"
+            headingLevel="h3"
+          >
+            AccordionItem Content here
+          </AccordionItem>
+
+        </Accordion>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+import Card from '../components/Card.vue';
+import Btn from '../components/Btn';
+import Accordion from '../components/Accordion.vue'
+import AccordionItem from '../components/AccordionItem.vue'
+import DownloadItem from '../components/DownloadItem.vue'
+import SvgIcon from '../components/SvgIcon.vue';
+
+export default {
+  name: 'MoreInfosAccordionSection',
+  components: {
+    Card,
+    Btn,
+    SvgIcon,
+    Accordion,
+    AccordionItem,
+    DownloadItem
+  },
+};
+</script>

--- a/app/components/ch/sections/MoreInfosAccordionSection.vue
+++ b/app/components/ch/sections/MoreInfosAccordionSection.vue
@@ -13,7 +13,7 @@
             title="Medienmitteilungen"
             headingLevel="h3"
           >
-            <h3 class="h5">Title h3</h3>
+            <h4 class="h5">Title h4</h4>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor</p>
             <ul class="list list--default">
               <li>List example</li>

--- a/app/components/ch/sections/MoreInfosAccordionSection.vue
+++ b/app/components/ch/sections/MoreInfosAccordionSection.vue
@@ -84,7 +84,7 @@
           </AccordionItem>
 
           <AccordionItem 
-            id="11"
+            id="12"
             title="Dokumente und Downloads"
             headingLevel="h3"
           >
@@ -109,7 +109,7 @@
           </AccordionItem>
 
           <AccordionItem 
-            id="11"
+            id="13"
             title="Reden"
             headingLevel="h3"
           >
@@ -131,7 +131,7 @@
           </AccordionItem>
 
           <AccordionItem 
-            id="11"
+            id="14"
             title="Parlament"
             headingLevel="h3"
           >
@@ -139,7 +139,7 @@
           </AccordionItem>
 
           <AccordionItem 
-            id="11"
+            id="15"
             title="Gesetze und Verordnungen"
             headingLevel="h3"
           >

--- a/app/components/stories/components/Accordion.stories.mdx
+++ b/app/components/stories/components/Accordion.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks'
 import Accordion from '../../ch/components/Accordion.vue'
+import AccordionItem from '../../ch/components/AccordionItem.vue'
 
 <Meta 
   title="Components/Accordion" 
@@ -8,8 +9,27 @@ import Accordion from '../../ch/components/Accordion.vue'
 
 export const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
-  components: { Accordion },
-  template: '<Accordion id="1" :content="content" />',
+  components: { Accordion, AccordionItem },
+  template: 
+    `
+    <Accordion id="1">
+      <AccordionItem 
+        id="10"
+        title="Accordion item one"
+        headingLevel="h2"
+      >
+        AccordionItem Content here
+      </AccordionItem>
+      <AccordionItem 
+        id="11"
+        title="Accordion item two"
+        headingLevel="h2"
+      >
+        AccordionItem Content here<br />
+        2nd line
+      </AccordionItem>
+    </Accordion>
+    `
 })
 
 
@@ -18,18 +38,13 @@ export const Template = (args, { argTypes }) => ({
 <Canvas>
   <Story
     name="Example"
-    args={{
-      content: [
-        { title: 'Accordion item one', content: 'Content here <br>second line' },
-        { title: "Accordion item two", content: "Content here <br>second line<br>third line" }
-      ]
-    }}
+    args={{}}
   >
     {Template.bind({})}
   </Story>
 </Canvas>
 
-# Interaction and accessibility
+# Interactions and accessibility
 
 Each accordion item regroup a button `.accordion__button`  and a related `.accordion__drawer`. Each button have an `aria-controls` attribute pointing the id of the drawer:
 
@@ -87,12 +102,24 @@ const Accordion = {
 export default Accordion
 ```
 
-<a href="?path=/story/components-accordion--example">
-  Go to the Canvas Tab
-</a>
+# Headings and accessibility
 
----
 
-<a href="?id=components-accordion--example" target="_blank">
-  Open page in full width in a new tab
-</a>
+## Accordion title
+Most of the time, the label of an accordion can be considered as a heading and should be marked with a `h2`, `h3` or a `h4`. 
+
+The heading level depends on the parent heading level and should respect the heading chain. For example, a `h4` heading shouldn't follow a `h2` title (use a `h3` instead). This rule applies on accordions titles too.
+
+More informations about [why heading levels should only increase by one](https://dequeuniversity.com/rules/axe/4.4/heading-order?application=axeAPI).
+
+## Titles inside an accordion
+Following the same logic, the titles inside an accordion content should be considered as subtitles of the accordion title. For example, if the accordion title is a `h3`, the following titles inside the accordion should start with a `h4` 
+
+## Rules of thumb
+
+1. __Accordion heading level = Parent title level + 1__
+2. __Heading level inside an accordion content = Accordion heading level + 1__
+
+If these rules can't be applied technically, for example in a complex migration process, the best option is to __remove the headings inside the accordions__. With this approach, the semantic of the titles is lost, but the content doesn't bring confusion for people using assistive technologies.  
+
+

--- a/app/components/stories/components/Accordion.stories.mdx
+++ b/app/components/stories/components/Accordion.stories.mdx
@@ -17,15 +17,14 @@ export const Template = (args, { argTypes }) => ({
         id="10"
         title="Accordion item one"
       >
-        <h4 class="h5">My parent title is a h3, therefore, I am a h4</h4>
+        <h4 class="h5">The title of the accordion item is a h3, therefore, as a subtitle, I am a h4 with a .h5 css class</h4>
         <p>Description here</p>
       </AccordionItem>
       <AccordionItem 
         id="11"
         title="Accordion item two"
       >
-        AccordionItem Content here<br />
-        2nd line
+        AccordionItem Content here
       </AccordionItem>
     </Accordion>
     `

--- a/app/components/stories/components/Accordion.stories.mdx
+++ b/app/components/stories/components/Accordion.stories.mdx
@@ -16,14 +16,13 @@ export const Template = (args, { argTypes }) => ({
       <AccordionItem 
         id="10"
         title="Accordion item one"
-        headingLevel="h2"
       >
-        AccordionItem Content here
+        <h4 class="h5">My parent title is a h3, therefore, I am a h4</h4>
+        <p>Description here</p>
       </AccordionItem>
       <AccordionItem 
         id="11"
         title="Accordion item two"
-        headingLevel="h2"
       >
         AccordionItem Content here<br />
         2nd line
@@ -115,11 +114,13 @@ More informations about [why heading levels should only increase by one](https:/
 ## Titles inside an accordion
 Following the same logic, the titles inside an accordion content should be considered as subtitles of the accordion title. For example, if the accordion title is a `h3`, the following titles inside the accordion should start with a `h4` 
 
+## Styles for titles inside an accordion
+The recommended style for any heading inside an accordion is the `.h5` CSS class. For example, a fourth level heading will adopt the `<h4 class="h5">` markup.
+
 ## Rules of thumb
 
 1. __Accordion heading level = Parent title level + 1__
 2. __Heading level inside an accordion content = Accordion heading level + 1__
 
 If these rules can't be applied technically, for example in a complex migration process, the best option is to __remove the headings inside the accordions__. With this approach, the semantic of the titles is lost, but the content doesn't bring confusion for people using assistive technologies.  
-
 

--- a/app/components/stories/components/Accordion.stories.mdx
+++ b/app/components/stories/components/Accordion.stories.mdx
@@ -72,7 +72,12 @@ Each accordion item regroup a button `.accordion__button`  and a related `.accor
 </ul>
 ```
 
-During interactions, some ARIA attributes have to be modified for a correct behaviour on assitive technologies. Below an example of a simple script which toggles `aria-expanded` and `aria-hidden` attributes:
+During interactions, some ARIA attributes have to be modified for a correct behaviour on assitive technologies. 
+
+Below an example of a simple script resolving two accessibility topics:
+1. Toggle `aria-expanded` and `aria-hidden` attributes on accordion button. 
+2. Hide the eventual focusable elements inside a closed accordion
+
 
 ```javascript
 const Accordion = {
@@ -80,18 +85,34 @@ const Accordion = {
     let buttons = document.querySelectorAll(target)
     buttons.forEach(button => {
       let content = button.nextElementSibling
+      let focusableElements = getFocusableElements(content)
+      // make focusable content unfocusable
+      focusableElements.forEach(item => {
+        item.tabIndex =  -1
+      })
+
       button.addEventListener("click", (event) => {
-        if (button.classList.contains("active")) {
+        if (button.classList.contains("active")) { 
+          // close drawer
           button.classList.remove("active")
           button.setAttribute("aria-expanded", false)
           content.style.maxHeight = null
           content.setAttribute("aria-hidden", true)
+          // make focusable content unfocusable
+          focusableElements.forEach(item => {
+            item.tabIndex =  -1
+          })
         }
         else {
+          // open drawer
           button.classList.add("active")
           content.style.maxHeight = content.scrollHeight + "px";
           content.setAttribute("aria-hidden", false)
           button.setAttribute("aria-expanded", true)
+          // make focusable content focusable again
+          focusableElements.forEach(item => {
+            item.tabIndex = undefined
+          })
         }
       })
     })

--- a/app/components/stories/components/Card.stories.mdx
+++ b/app/components/stories/components/Card.stories.mdx
@@ -8,7 +8,7 @@ import Card from '../../ch/components/Card.vue';
     type: { 
       control: { 
         type: 'select', 
-        options: ['default', 'highlight', 'image-left', 'twitter', 'flat'] 
+        options: ['default', 'highlight', 'twitter', 'flat'] 
       } 
     },
     image: { 

--- a/app/components/stories/components/Card.stories.mdx
+++ b/app/components/stories/components/Card.stories.mdx
@@ -8,7 +8,7 @@ import Card from '../../ch/components/Card.vue';
     type: { 
       control: { 
         type: 'select', 
-        options: ['default', 'highlight'] 
+        options: ['default', 'highlight', 'image-left', 'twitter', 'flat'] 
       } 
     },
     image: { 
@@ -43,43 +43,41 @@ export const Template = (args, { argTypes }) => ({
   components: { Card },
   template:
     `
-    <Card :type="type">   
-      <template v-if="${args.header == 'WithHeader'}" v-slot:header>
-        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="mr-2 icon icon--xl icon--Twitter "><path xmlns="http://www.w3.org/2000/svg" d="m9.312 18.744a11.758 11.758 0 0 1 -5.694-1.844.35.35 0 0 1 .178-.645 12.242 12.242 0 0 0 3.525-.679 3.826 3.826 0 0 1 -1.75-2.155l-.194-.6a.356.356 0 0 1 0-.212 3.809 3.809 0 0 1 -.924-2.49v-.679a.352.352 0 0 1 .172-.3.422.422 0 0 1 .053-.025 3.827 3.827 0 0 1 .322-3.141l.27-.474a.35.35 0 0 1 .574-.045l.343.422a8.006 8.006 0 0 0 5 2.876 3.819 3.819 0 0 1 6.288-2.8 5.445 5.445 0 0 0 1.376-.579l1.449-.906a.246.246 0 0 1 .36.286l-.743 1.467q-.015.049-.033.1l1.5-.311a.245.245 0 0 1 .3.36s-2.309 2.363-2.855 2.806v.048a9.428 9.428 0 0 1 -9.517 9.52zm-4.346-1.886a10.578 10.578 0 0 0 4.346 1.186 8.736 8.736 0 0 0 8.821-8.821v-.206a.35.35 0 0 1 .136-.287c.545-.419 2.17-1.983 2.17-1.983s-1.637.516-1.762.563c-.142.055-.109-.11-.023-.236.172-.249.966-1.495.966-1.495a12.349 12.349 0 0 1 -2.156 1.1.346.346 0 0 1 -.318-.086 3.118 3.118 0 0 0 -5.255 2.271c0 .088 0 .175.01.262a.348.348 0 0 1 -.1.28.354.354 0 0 1 -.282.1 8.706 8.706 0 0 1 -5.875-3.183l-.024-.03-.02.034a3.123 3.123 0 0 0 .063 3.239.35.35 0 0 1 -.453.5l-.058-.032v.045a3.136 3.136 0 0 0 1.117 2.43.35.35 0 0 1 -.071.582l.039.119a3.124 3.124 0 0 0 2.02 2.019.35.35 0 0 1 .072.634 9.276 9.276 0 0 1 -3.363.995z"></path></svg>
-        <div>Tweets from @swiss_geoportal</div>
-      </template>
-      <template v-if="${args.footerInfo == 'WithFooterInfo'}" v-slot:footerInfo>
-        <div>FooterInfo</div>
-      </template>
-      <template v-if="${args.footerAction == 'WithFooterAction'}" v-slot:footerAction>
-        <button type="button" aria-label="Weiterlesen" class="btn btn--outline btn--icon-only "><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="btn__icon icon icon--base icon--ArrowRight "><path xmlns="http://www.w3.org/2000/svg" d="m16.444 19.204 4.066-7.044-4.066-7.044-.65.375 3.633 6.294h-15.187v.75h15.187l-3.633 6.294z"></path></svg> <span class="btn__text">
-          Weiterlesen
-        </span></button>
-      </template>
-      <template v-if="${args.image == 'WithImage'}" v-slot:image>
-        <img src="https://placekitten.com/g/775/350" alt="cat">
-      </template>
-      <template v-if="${'body' in args}" v-slot:body>
-        <h3 class="card__title">Card title</h3>
-        <p>
-          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed Lorem ipsum dolor sit amet,
-          consetetur sadipscing elitr, sed Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
-          sed Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
-        </p>
-      </template>
-    </Card>
+    <div style="padding: 3em; background-color: rgb(240, 244, 247);">
+      <div style="max-width: 600px; margin: auto">
+        <Card :type="type">   
+          <template v-if="${args.header == 'WithHeader'}" v-slot:header>
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="mr-2 icon icon--xl icon--Twitter "><path xmlns="http://www.w3.org/2000/svg" d="m9.312 18.744a11.758 11.758 0 0 1 -5.694-1.844.35.35 0 0 1 .178-.645 12.242 12.242 0 0 0 3.525-.679 3.826 3.826 0 0 1 -1.75-2.155l-.194-.6a.356.356 0 0 1 0-.212 3.809 3.809 0 0 1 -.924-2.49v-.679a.352.352 0 0 1 .172-.3.422.422 0 0 1 .053-.025 3.827 3.827 0 0 1 .322-3.141l.27-.474a.35.35 0 0 1 .574-.045l.343.422a8.006 8.006 0 0 0 5 2.876 3.819 3.819 0 0 1 6.288-2.8 5.445 5.445 0 0 0 1.376-.579l1.449-.906a.246.246 0 0 1 .36.286l-.743 1.467q-.015.049-.033.1l1.5-.311a.245.245 0 0 1 .3.36s-2.309 2.363-2.855 2.806v.048a9.428 9.428 0 0 1 -9.517 9.52zm-4.346-1.886a10.578 10.578 0 0 0 4.346 1.186 8.736 8.736 0 0 0 8.821-8.821v-.206a.35.35 0 0 1 .136-.287c.545-.419 2.17-1.983 2.17-1.983s-1.637.516-1.762.563c-.142.055-.109-.11-.023-.236.172-.249.966-1.495.966-1.495a12.349 12.349 0 0 1 -2.156 1.1.346.346 0 0 1 -.318-.086 3.118 3.118 0 0 0 -5.255 2.271c0 .088 0 .175.01.262a.348.348 0 0 1 -.1.28.354.354 0 0 1 -.282.1 8.706 8.706 0 0 1 -5.875-3.183l-.024-.03-.02.034a3.123 3.123 0 0 0 .063 3.239.35.35 0 0 1 -.453.5l-.058-.032v.045a3.136 3.136 0 0 0 1.117 2.43.35.35 0 0 1 -.071.582l.039.119a3.124 3.124 0 0 0 2.02 2.019.35.35 0 0 1 .072.634 9.276 9.276 0 0 1 -3.363.995z"></path></svg>
+            <div>Tweets from @swiss_geoportal</div>
+          </template>
+          <template v-if="${args.footerInfo == 'WithFooterInfo'}" v-slot:footerInfo>
+            <div>FooterInfo</div>
+          </template>
+          <template v-if="${args.footerAction == 'WithFooterAction'}" v-slot:footerAction>
+            <button type="button" aria-label="Weiterlesen" class="btn btn--outline btn--icon-only "><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="btn__icon icon icon--base icon--ArrowRight "><path xmlns="http://www.w3.org/2000/svg" d="m16.444 19.204 4.066-7.044-4.066-7.044-.65.375 3.633 6.294h-15.187v.75h15.187l-3.633 6.294z"></path></svg> <span class="btn__text">
+              Weiterlesen
+            </span></button>
+          </template>
+          <template v-if="${args.image == 'WithImage'}" v-slot:image>
+            <img src="https://placekitten.com/g/775/350" alt="cat">
+          </template>
+          <template v-slot:body>
+            <h3 class="card__title">Card title</h3>
+            <p>
+              Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed Lorem ipsum dolor sit amet,
+              consetetur sadipscing elitr, sed Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
+              sed Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+            </p>
+          </template>
+        </Card>
+      </div>
+    </div>
     `,
 });
 
 export const Default = Template.bind({});
 Default.args = {
   body: 'Design System for <br/>the Swiss Confederation',
-}
-
-export const WithImage = Template.bind({});
-Default.args = {
-  body: 'WithImageDesign System for <br/>the Swiss Confederation',
-  image: '',
 }
 
 
@@ -95,7 +93,8 @@ Default.args = {
       image: 'WithImage',
       header: 'NoHeader',
       footerInfo: 'NoFooterInfo',
-      footerAction: 'NoFooterAction'
+      footerAction: 'NoFooterAction',
+      body: 'Lorem '
     }}
   >
     {Template.bind({})}

--- a/app/components/stories/pages/DetailpageComplex.stories.mdx
+++ b/app/components/stories/pages/DetailpageComplex.stories.mdx
@@ -20,6 +20,12 @@ export const Template = (args, { argTypes }) => ({
 
 # Complex page example
 
+<a href="?path=/story/pages-detail-page-complex--example">Go to the Canvas Tab</a>
+
+---
+
+<a href="?id=pages-detail-page-complex--example" target="_blank">Open in full width in a new tab</a>
+
 <Canvas>
   <Story
     name="Example"
@@ -31,9 +37,4 @@ export const Template = (args, { argTypes }) => ({
   </Story>
 </Canvas>
 
-<a href="?path=/story/pages-detail-page-complex--example">Go to the Canvas Tab</a>
-
----
-
-<a href="?id=pages-detail-page-complex--example" target="_blank">Open page in full width in a new tab</a>
 

--- a/app/components/stories/pages/DetailpageSimple.stories.mdx
+++ b/app/components/stories/pages/DetailpageSimple.stories.mdx
@@ -20,6 +20,12 @@ export const Template = (args, { argTypes }) => ({
 
 # Simple page example
 
+<a href="?path=/story/pages-detail-page-simple--example">Go to the Canvas Tab</a>
+
+---
+
+<a href="?id=pages-detail-page-simple--example" target="_blank">Open page in full width in a new tab</a>
+
 <Canvas>
   <Story
     name="Example"
@@ -31,9 +37,4 @@ export const Template = (args, { argTypes }) => ({
   </Story>
 </Canvas>
 
-<a href="?path=/story/pages-detail-page-simple--example">Go to the Canvas Tab</a>
-
----
-
-<a href="?id=pages-detail-page-simple--example" target="_blank">Open page in full width in a new tab</a>
 

--- a/app/components/stories/pages/Forms.stories.mdx
+++ b/app/components/stories/pages/Forms.stories.mdx
@@ -20,6 +20,12 @@ export const Template = (args, { argTypes }) => ({
 
 # Homepage example
 
+<a href="?path=/story/pages-form-example--example">Go to the Canvas Tab</a>
+
+---
+
+<a href="?id=pages-form-example--example" target="_blank">Open page in full width in a new tab</a>
+
 <Canvas>
   <Story
     name="Form Example"
@@ -31,9 +37,4 @@ export const Template = (args, { argTypes }) => ({
   </Story>
 </Canvas>
 
-<a href="?path=/story/pages-form-example--example">Go to the Canvas Tab</a>
-
----
-
-<a href="?id=pages-form-example--example" target="_blank">Open page in full width in a new tab</a>
 

--- a/app/components/stories/pages/Homepage.stories.mdx
+++ b/app/components/stories/pages/Homepage.stories.mdx
@@ -20,6 +20,12 @@ export const Template = (args, { argTypes }) => ({
 
 # Homepage example
 
+<a href="?path=/story/pages-homepage--example">Go to the Canvas Tab</a>
+
+---
+
+<a href="?id=pages-homepage--example" target="_blank">Open in full width in a new tab</a>
+
 <Canvas>
   <Story
     name="Example"
@@ -30,10 +36,4 @@ export const Template = (args, { argTypes }) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<a href="?path=/story/pages-homepage--example">Go to the Canvas Tab</a>
-
----
-
-<a href="?id=pages-homepage--example" target="_blank">Open page in full width in a new tab</a>
 

--- a/app/components/stories/pages/Hubpage.stories.mdx
+++ b/app/components/stories/pages/Hubpage.stories.mdx
@@ -20,6 +20,12 @@ export const Template = (args, { argTypes }) => ({
 
 # Hub page example
 
+<a href="?path=/story/pages-hub-page--example">Go to the Canvas Tab</a>
+
+---
+
+<a href="?id=pages-hub-page--example" target="_blank">Open page in full width in a new tab</a>
+
 <Canvas>
   <Story
     name="Example"
@@ -31,9 +37,4 @@ export const Template = (args, { argTypes }) => ({
   </Story>
 </Canvas>
 
-<a href="?path=/story/pages-hub-page--example">Go to the Canvas Tab</a>
-
----
-
-<a href="?id=pages-hub-page--example" target="_blank">Open page in full width in a new tab</a>
 

--- a/app/components/stories/pages/Searchresults.stories.mdx
+++ b/app/components/stories/pages/Searchresults.stories.mdx
@@ -62,6 +62,12 @@ export const Template = (args, { argTypes }) => ({
 
 # Loading example
 
+<a href="?path=/story/pages-search-results--example">Go to the Canvas Tab</a>
+
+---
+
+<a href="?id=pages-search-results--when-loading&args=&viewMode=story" target="_blank">Open page in full width in a new tab</a>
+
 <Canvas>
   <Story
     name="When Loading"
@@ -74,9 +80,4 @@ export const Template = (args, { argTypes }) => ({
   </Story>
 </Canvas>
 
-<a href="?path=/story/pages-search-results--example">Go to the Canvas Tab</a>
-
----
-
-<a href="?id=pages-search-results--when-loading&args=&viewMode=story" target="_blank">Open page in full width in a new tab</a>
 

--- a/app/components/stories/sections/MoreInfosAccordionSection.stories.mdx
+++ b/app/components/stories/sections/MoreInfosAccordionSection.stories.mdx
@@ -14,7 +14,13 @@ export const Template = () => ({
     `,
 })
 
-# Contact Section
+# More Infos Section
+
+Example of an accordion with complex content: 
+- Rich text (1st drawer)
+- Cards (2nd drawer). Inside an accordion, cards should be displayed with their `card--flat` variant
+- Download items (3rd drawer)
+- Picture (4th drawer)
 
 <Canvas>
   <Story name="Example">{Template.bind({})}</Story>

--- a/app/components/stories/sections/MoreInfosAccordionSection.stories.mdx
+++ b/app/components/stories/sections/MoreInfosAccordionSection.stories.mdx
@@ -22,18 +22,9 @@ Example of an accordion with complex content:
 - Download items (3rd drawer)
 - Picture (4th drawer)
 
+This section is displayed at the bottom of the [detail page example](?path=/docs/pages-detail-page-simple--example)
+
 <Canvas>
   <Story name="Example">{Template.bind({})}</Story>
 </Canvas>
 
-<!--ArgsTable story="Example" /-->
-
-<a href="?path=/story/sections-content-more-infos--example">
-  Go to the Canvas Tab
-</a>
-
----
-    
-<a href="?id=sections-content-more-infos--example&args=&viewMode=story" target="_blank">
-  Open page in full width in a new tab
-</a>

--- a/app/components/stories/sections/MoreInfosAccordionSection.stories.mdx
+++ b/app/components/stories/sections/MoreInfosAccordionSection.stories.mdx
@@ -1,0 +1,33 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
+import MoreInfosAccordionSection from '../../ch/sections/MoreInfosAccordionSection.vue'
+
+<Meta title="Sections/Content/More Infos" component={MoreInfosAccordionSection} />
+
+export const Template = () => ({
+  props: [],
+  components: { MoreInfosAccordionSection },
+  template: 
+    `
+    <main>
+      <MoreInfosAccordionSection />
+    </main>
+    `,
+})
+
+# Contact Section
+
+<Canvas>
+  <Story name="Example">{Template.bind({})}</Story>
+</Canvas>
+
+<!--ArgsTable story="Example" /-->
+
+<a href="?path=/story/sections-content-more-infos--example">
+  Go to the Canvas Tab
+</a>
+
+---
+    
+<a href="?id=sections-content-more-infos--example&args=&viewMode=story" target="_blank">
+  Open page in full width in a new tab
+</a>

--- a/app/pages/detailPageSimple.vue
+++ b/app/pages/detailPageSimple.vue
@@ -287,26 +287,6 @@
               </li>
             </ol>
 
-            <Accordion
-              id="3456"
-              :content="[
-                {
-                  title: 'Accordion item one',
-                  content: 'Content here <br>second line',
-                },
-                {
-                  title: 'Accordion item two',
-                  content: 'Content here <br>second line<br>third line',
-                },
-                {
-                  title:
-                    'Accordion item three. this one has a long title, like this we can test how it displays on two lines',
-                  content:
-                    '<h4 class=&quot;h3&quot;>Demo list</h4><ul class=&quot;list list--bullet&quot;><li>list item</li><li>list item</li></ul>',
-                },
-              ]"
-            />
-
             <h2 class="h2">Datenmodellablage ansehen</h2>
             <p>
               Der Modellkatalog kann unter
@@ -404,6 +384,8 @@
         </div>
       </section>
 
+      <MoreInfosAccordionSection />
+
       <ContactSection />
     </main>
     <footer class="footer" id="main-footer">
@@ -425,7 +407,7 @@ import FooterNavigation from '../components/ch/sections/FooterNavigation.vue'
 import Hero from '~/components/ch/sections/Hero'
 import QuoteSection from '~/components/ch/sections/QuoteSection'
 import ContactSection from '~/components/ch/sections/ContactSection'
-import Accordion from '~/components/ch/components/Accordion'
+import MoreInfosAccordionSection from '~/components/ch/sections/MoreInfosAccordionSection'
 import TextImage from '~/components/ch/components/TextImage'
 import AudioPlayer from '~/components/ch/components/AudioPlayer'
 import SlideshowExample from '~/components/ch/demo/SlideshowExample.vue'
@@ -447,7 +429,7 @@ export default {
     Hero,
     QuoteSection,
     ContactSection,
-    Accordion,
+    MoreInfosAccordionSection,
     TextImage,
     AudioPlayer,
     SlideshowExample,

--- a/app/scripts/Accordion.js
+++ b/app/scripts/Accordion.js
@@ -1,20 +1,46 @@
+function getFocusableElements (element = document) {
+  return [
+    ...element.querySelectorAll(
+      'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
+    )
+  ].filter(
+    el => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden')
+  )
+}
+
 const Accordion = {
   init(target) {
     let buttons = document.querySelectorAll(target)
     buttons.forEach(button => {
       let content = button.nextElementSibling
+      let focusableElements = getFocusableElements(content)
+      // make focusable content unfocusable
+      focusableElements.forEach(item => {
+        item.tabIndex =  -1
+      })
+
       button.addEventListener("click", (event) => {
-        if (button.classList.contains("active")) {
+        if (button.classList.contains("active")) { 
+          // close drawer
           button.classList.remove("active")
           button.setAttribute("aria-expanded", false)
           content.style.maxHeight = null
           content.setAttribute("aria-hidden", true)
+          // make focusable content unfocusable
+          focusableElements.forEach(item => {
+            item.tabIndex =  -1
+          })
         }
         else {
+          // open drawer
           button.classList.add("active")
           content.style.maxHeight = content.scrollHeight + "px";
           content.setAttribute("aria-hidden", false)
           button.setAttribute("aria-expanded", true)
+          // make focusable content focusable again
+          focusableElements.forEach(item => {
+            item.tabIndex = undefined
+          })
         }
       })
     })

--- a/css/components/accordion.postcss
+++ b/css/components/accordion.postcss
@@ -49,6 +49,7 @@ main .accordion {
 
 .accordion__content {
   @apply w-full px-2 pt-4 pb-10 2xl:px-3;
+  @apply vertical-spacing;
 }
 
 .accordion__title {

--- a/css/components/card.postcss
+++ b/css/components/card.postcss
@@ -65,31 +65,45 @@
   }
 }
 
-.card--flat {
-  @apply search-result;
-
+.card--flat.card--clickable {
   &:hover,
   &:focus-within {
+    @apply bg-secondary-50;
     @apply shadow-none;
   }
-
-  .card__content {
-    @apply bg-transparent;
-  }
-
-  .card__body {
-    @apply p-0;
-    max-height: none;
-  }
-
-  .card__footer {
-    @apply p-0;
-  }
-
-  .accordion .accordion__drawer & {
-    @apply mt-0;
-  }
 }
+
+.card--flat {
+  @apply py-4 lg:py-6 2xl:py-8;
+  @apply px-2;
+  @apply border-b border-secondary-300;
+  
+  @apply transition-colors duration-200 ease-in-out;
+}
+  
+/* card--flat is extended for .search-result items */
+.card--flat .card__content {
+  @apply bg-transparent;
+}
+
+/* therefore, specific definitions for card--flat children are not nested:  */
+.card--flat .card__body {
+  max-height: none;
+  @apply px-0;
+}
+
+.card--flat .card__content:first-of-type .card__body {
+  @apply py-0;
+}
+
+.card--flat .card__footer {
+  @apply p-0;
+}
+
+.accordion .accordion__drawer .card--flat {
+  @apply mt-0;
+}
+
 
 .card__image {
   @apply relative pb-[56.25%]; /* 16/9 ratio */

--- a/css/components/card.postcss
+++ b/css/components/card.postcss
@@ -68,17 +68,18 @@
 .card--flat.card--clickable {
   &:hover,
   &:focus-within {
-    @apply bg-secondary-50;
+    @apply bg-transparent;
     @apply shadow-none;
+
+    &:hover .card__title {
+      @apply text-red-600;
+    }
   }
 }
 
 .card--flat {
   @apply py-4 lg:py-6 2xl:py-8;
-  @apply px-2;
   @apply border-b border-secondary-200;
-  
-  @apply transition-colors duration-200 ease-in-out;
 }
   
 /* card--flat is extended for .search-result items */
@@ -88,8 +89,8 @@
 
 /* therefore, specific definitions for card--flat children are not nested:  */
 .card--flat .card__body {
-  max-height: none;
   @apply px-0;
+  max-height: none;
 }
 
 .card--flat .card__content:first-of-type .card__body {
@@ -144,6 +145,7 @@
 .card__title {
   @apply text-lg xl:text-xl 3xl:text-2xl;
   @apply font-bold leading-6;
+  @apply transition-colors duration-200 ease-in-out;
 }
 
 .card__footer {

--- a/css/components/card.postcss
+++ b/css/components/card.postcss
@@ -76,7 +76,7 @@
 .card--flat {
   @apply py-4 lg:py-6 2xl:py-8;
   @apply px-2;
-  @apply border-b border-secondary-300;
+  @apply border-b border-secondary-200;
   
   @apply transition-colors duration-200 ease-in-out;
 }
@@ -102,6 +102,11 @@
 
 .accordion .accordion__drawer .card--flat {
   @apply mt-0;
+
+  &:last-of-type {
+    @apply mb-4; 
+    @apply border-b-0;
+  }
 }
 
 

--- a/css/components/card.postcss
+++ b/css/components/card.postcss
@@ -65,6 +65,32 @@
   }
 }
 
+.card--flat {
+  @apply search-result;
+
+  &:hover,
+  &:focus-within {
+    @apply shadow-none;
+  }
+
+  .card__content {
+    @apply bg-transparent;
+  }
+
+  .card__body {
+    @apply p-0;
+    max-height: none;
+  }
+
+  .card__footer {
+    @apply p-0;
+  }
+
+  .accordion .accordion__drawer & {
+    @apply mt-0;
+  }
+}
+
 .card__image {
   @apply relative pb-[56.25%]; /* 16/9 ratio */
   @apply overflow-hidden;

--- a/css/components/download-item.postcss
+++ b/css/components/download-item.postcss
@@ -7,11 +7,9 @@
   @apply pl-0 pb-4 pt-4;
   @apply border-b border-secondary-200;
   @apply text-left;
-  @apply hover:bg-secondary-50;
 
   .bg--secondary-50 & {
     @apply border-secondary-300;
-    @apply hover:bg-white;
   }
 
   .accordion &:last-of-type {
@@ -21,12 +19,18 @@
 }
 
 .download-item__icon {
-  @apply pr-2 md:pr-4 xl:pr-6;
+  @apply -ml-1;
+  @apply pr-1 md:pr-2;
   @apply text-red-600;
 }
 
 .download-item__title {
   @apply font-bold;
+  @apply transition-colors duration-200;
+
+  .download-item:hover & {
+    @apply text-red-600;
+  }
 }
 
 .download-item__meta-info {

--- a/css/components/download-item.postcss
+++ b/css/components/download-item.postcss
@@ -5,13 +5,18 @@
 .download-item {
   @apply flex w-full;
   @apply pl-0 pb-4 pt-4;
-  @apply border-b border-gray-200;
+  @apply border-b border-secondary-200;
   @apply text-left;
   @apply hover:bg-secondary-50;
 
   .bg--secondary-50 & {
-    @apply border-gray-300;
+    @apply border-secondary-300;
     @apply hover:bg-white;
+  }
+
+  .accordion &:last-of-type {
+    @apply mb-4; 
+    @apply border-b-0;
   }
 }
 

--- a/css/components/search.postcss
+++ b/css/components/search.postcss
@@ -203,6 +203,7 @@
 \*----------------------------------------*/
 
 .search-result {
+  @apply card--flat;
 
   @apply block space-y-4;
   
@@ -210,11 +211,6 @@
     @apply grid gap-x-6;
     grid-template-columns: 4fr 1fr;
   }
-
-  @apply py-4 lg:py-6 2xl:py-8;
-  @apply px-2;
-  @apply border-b border-secondary-300;
-  @apply transition-colors duration-200 ease-in-out;
 
   &:hover {
     @apply bg-secondary-50;
@@ -232,7 +228,6 @@
 
 .search-result__description {
   grid-column: 1 / 2;
-  /* @apply sm:w-2/3 space-y-2 lg:space-y-3 2xl:space-y-4; */
 }
 
 .search-result__specs,

--- a/css/components/search.postcss
+++ b/css/components/search.postcss
@@ -212,10 +212,6 @@
     grid-template-columns: 4fr 1fr;
   }
 
-  &:hover {
-    @apply bg-secondary-50;
-  }
-
   .meta-info {
     grid-column: 1 / 2;
   }
@@ -224,6 +220,12 @@
 .search-result__title {
   grid-column: 1 / 2;
   @apply text--xl text--bold;
+  @apply transition-colors duration-200;
+
+
+  .search-result:hover & {
+    @apply text-primary-600;
+  }
 }
 
 .search-result__description {

--- a/css/foundations/icons.postcss
+++ b/css/foundations/icons.postcss
@@ -32,7 +32,7 @@
 }
 
 .icon--xl {
-  @apply h-7 md:h-8;
+  @apply h-7 md:h-8 lg:h-9;
 }
 
 .icon--2xl {


### PR DESCRIPTION
## Features
- new `.card--flat` variant [link here], based on `.search-result` design `.flat--card` is used in the accordion content. Example in Sections/Content/More Infos [link ]

## Documentation
- Improved Documentation for accordions, explaining best practice regarding heading inside accordions [link here]

## Improvements
- Refactor Accordion: complex content (components) can be displayed in the content
- Refactor Card and search results: `.search-result` is now extending `.flat--card`, not the opposite


